### PR TITLE
feat(chat): Implement DeepSeek API integration for backend chat logic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,10 +75,17 @@ dependencies {
     implementation(libs.retrofit.core)
     implementation(libs.retrofit.moshi)
     
+    // OkHttp
+    implementation(libs.okhttp.core)
+    implementation(libs.okhttp.logging)
+    
     // Moshi
     implementation(libs.moshi.core)
     implementation(libs.moshi.kotlin)
     ksp(libs.moshi.codegen)
+    
+    // Annotations
+    implementation(libs.javax.annotation)
     
     // Coroutines
     implementation(libs.kotlinx.coroutines.core)

--- a/app/src/main/java/com/demo/smartchatbotapp/data/local/ChatMessageDao.kt
+++ b/app/src/main/java/com/demo/smartchatbotapp/data/local/ChatMessageDao.kt
@@ -1,0 +1,18 @@
+package com.demo.smartchatbotapp.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.demo.smartchatbotapp.domain.model.ChatMessage
+
+@Dao
+interface ChatMessageDao {
+    @Query("SELECT * FROM chat_messages ORDER BY timestamp ASC")
+    suspend fun getAllMessages(): List<ChatMessage>
+
+    @Insert
+    suspend fun insertMessage(message: ChatMessage): Long
+
+    @Query("DELETE FROM chat_messages")
+    suspend fun clearChatHistory()
+} 

--- a/app/src/main/java/com/demo/smartchatbotapp/data/local/dao/ChatMessageDao.kt
+++ b/app/src/main/java/com/demo/smartchatbotapp/data/local/dao/ChatMessageDao.kt
@@ -2,15 +2,17 @@ package com.demo.smartchatbotapp.data.local.dao
 
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.demo.smartchatbotapp.data.local.entity.ChatMessageEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ChatMessageDao {
     @Query("SELECT * FROM chat_messages ORDER BY timestamp ASC")
-    suspend fun getAllMessages(): List<ChatMessageEntity>
+    fun getAllMessages(): Flow<List<ChatMessageEntity>>
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertMessage(message: ChatMessageEntity): Long
 
     @Query("DELETE FROM chat_messages")

--- a/app/src/main/java/com/demo/smartchatbotapp/data/remote/ChatApiService.kt
+++ b/app/src/main/java/com/demo/smartchatbotapp/data/remote/ChatApiService.kt
@@ -1,0 +1,32 @@
+package com.demo.smartchatbotapp.data.remote
+
+import com.demo.smartchatbotapp.data.remote.model.ChatRequest
+import com.demo.smartchatbotapp.data.remote.model.ChatResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface ChatApiService {
+    @POST("chat/completions")
+    suspend fun sendMessage(@Body request: ChatRequest): ChatResponse
+}
+
+data class ChatRequest(
+    val model: String = "gpt-3.5-turbo",
+    val messages: List<Message>,
+    val temperature: Double = 0.7
+)
+
+data class Message(
+    val role: String,
+    val content: String
+)
+
+data class ChatResponse(
+    val id: String,
+    val choices: List<Choice>
+)
+
+data class Choice(
+    val message: Message,
+    val finish_reason: String
+) 

--- a/app/src/main/java/com/demo/smartchatbotapp/data/remote/model/ChatRequest.kt
+++ b/app/src/main/java/com/demo/smartchatbotapp/data/remote/model/ChatRequest.kt
@@ -1,0 +1,19 @@
+package com.demo.smartchatbotapp.data.remote.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ChatRequest(
+    @Json(name = "model") val model: String = "deepseek-chat",
+    @Json(name = "messages") val messages: List<Message>,
+    @Json(name = "temperature") val temperature: Double = 0.7,
+    @Json(name = "max_tokens") val maxTokens: Int = 1000,
+    @Json(name = "stream") val stream: Boolean = false
+)
+
+@JsonClass(generateAdapter = true)
+data class Message(
+    @Json(name = "role") val role: String,
+    @Json(name = "content") val content: String
+) 

--- a/app/src/main/java/com/demo/smartchatbotapp/data/remote/model/ChatResponse.kt
+++ b/app/src/main/java/com/demo/smartchatbotapp/data/remote/model/ChatResponse.kt
@@ -1,0 +1,28 @@
+package com.demo.smartchatbotapp.data.remote.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ChatResponse(
+    @Json(name = "id") val id: String,
+    @Json(name = "object") val objectType: String,
+    @Json(name = "created") val created: Long,
+    @Json(name = "model") val model: String,
+    @Json(name = "choices") val choices: List<Choice>,
+    @Json(name = "usage") val usage: Usage
+)
+
+@JsonClass(generateAdapter = true)
+data class Choice(
+    @Json(name = "index") val index: Int,
+    @Json(name = "message") val message: Message,
+    @Json(name = "finish_reason") val finishReason: String
+)
+
+@JsonClass(generateAdapter = true)
+data class Usage(
+    @Json(name = "prompt_tokens") val promptTokens: Int,
+    @Json(name = "completion_tokens") val completionTokens: Int,
+    @Json(name = "total_tokens") val totalTokens: Int
+) 

--- a/app/src/main/java/com/demo/smartchatbotapp/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/com/demo/smartchatbotapp/data/repository/ChatRepositoryImpl.kt
@@ -3,10 +3,13 @@ package com.demo.smartchatbotapp.data.repository
 import com.demo.smartchatbotapp.data.local.dao.ChatMessageDao
 import com.demo.smartchatbotapp.data.local.entity.ChatMessageEntity
 import com.demo.smartchatbotapp.data.remote.ChatApiService
-import com.demo.smartchatbotapp.data.remote.ChatRequest
-import com.demo.smartchatbotapp.data.remote.Message
+import com.demo.smartchatbotapp.data.remote.model.ChatRequest
+import com.demo.smartchatbotapp.data.remote.model.ChatResponse
+import com.demo.smartchatbotapp.data.remote.model.Message
 import com.demo.smartchatbotapp.domain.model.ChatMessage
 import com.demo.smartchatbotapp.domain.repository.ChatRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class ChatRepositoryImpl @Inject constructor(
@@ -14,36 +17,47 @@ class ChatRepositoryImpl @Inject constructor(
     private val api: ChatApiService
 ) : ChatRepository {
 
-    override suspend fun getChatHistory(): List<ChatMessage> {
-        return dao.getAllMessages().map { it.toDomain() }
+    override fun getChatHistory(): Flow<List<ChatMessage>> {
+        return dao.getAllMessages().map { entities ->
+            entities.map { it.toDomain() }
+        }
     }
 
     override suspend fun sendMessage(message: String): Result<ChatMessage> {
         return try {
             // Save user message
-            val userMessage = ChatMessageEntity(
-                content = message,
-                isUser = true
+            val userMessageId = dao.insertMessage(
+                ChatMessageEntity(
+                    content = message,
+                    isUser = true
+                )
             )
-            dao.insertMessage(userMessage)
 
             // Send to API
             val response = api.sendMessage(
                 ChatRequest(
-                    messages = listOf(
-                        Message(role = "user", content = message)
-                    )
+                    model = "deepseek-chat",
+                    messages = listOf(Message(role = "user", content = message))
                 )
             )
 
             // Save bot response
-            val botMessage = ChatMessageEntity(
-                content = response.choices.firstOrNull()?.message?.content ?: "No response",
-                isUser = false
-            )
-            dao.insertMessage(botMessage)
-
-            Result.success(botMessage.toDomain())
+            val botMessage = response.choices.firstOrNull()?.message
+            if (botMessage != null) {
+                val botMessageId = dao.insertMessage(
+                    ChatMessageEntity(
+                        content = botMessage.content,
+                        isUser = false
+                    )
+                )
+                Result.success(ChatMessage(
+                    id = botMessageId,
+                    content = botMessage.content,
+                    isUser = false
+                ))
+            } else {
+                Result.failure(Exception("No response from API"))
+            }
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -53,10 +67,12 @@ class ChatRepositoryImpl @Inject constructor(
         dao.clearChatHistory()
     }
 
-    private fun ChatMessageEntity.toDomain() = ChatMessage(
-        id = id,
-        content = content,
-        isUser = isUser,
-        timestamp = timestamp
-    )
+    private fun ChatMessageEntity.toDomain(): ChatMessage {
+        return ChatMessage(
+            id = id,
+            content = content,
+            isUser = isUser,
+            timestamp = timestamp
+        )
+    }
 } 

--- a/app/src/main/java/com/demo/smartchatbotapp/di/NetworkModule.kt
+++ b/app/src/main/java/com/demo/smartchatbotapp/di/NetworkModule.kt
@@ -1,0 +1,69 @@
+package com.demo.smartchatbotapp.di
+
+import com.demo.smartchatbotapp.data.remote.ChatApiService
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    private const val BASE_URL = "https://api.deepseek.com/v1/"
+    private const val API_KEY = "YOUR_API_KEY"
+
+    @Provides
+    @Singleton
+    fun provideMoshi(): Moshi {
+        return Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val original = chain.request()
+                val request = original.newBuilder()
+                    .header("Authorization", "Bearer $API_KEY")
+                    .header("Content-Type", "application/json")
+                    .method(original.method, original.body)
+                    .build()
+                chain.proceed(request)
+            }
+            .addInterceptor(HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            })
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(moshi: Moshi, okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideChatApiService(retrofit: Retrofit): ChatApiService {
+        return retrofit.create(ChatApiService::class.java)
+    }
+} 

--- a/app/src/main/java/com/demo/smartchatbotapp/di/RepositoryModule.kt
+++ b/app/src/main/java/com/demo/smartchatbotapp/di/RepositoryModule.kt
@@ -1,0 +1,34 @@
+package com.demo.smartchatbotapp.di
+
+import com.demo.smartchatbotapp.data.local.dao.ChatMessageDao
+import com.demo.smartchatbotapp.data.remote.ChatApiService
+import com.demo.smartchatbotapp.data.repository.ChatRepositoryImpl
+import com.demo.smartchatbotapp.domain.repository.ChatRepository
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindChatRepository(
+        chatRepositoryImpl: ChatRepositoryImpl
+    ): ChatRepository
+
+    companion object {
+        @Provides
+        @Singleton
+        fun provideChatRepositoryImpl(
+            dao: ChatMessageDao,
+            api: ChatApiService
+        ): ChatRepositoryImpl {
+            return ChatRepositoryImpl(dao, api)
+        }
+    }
+} 

--- a/app/src/main/java/com/demo/smartchatbotapp/di/UseCaseModule.kt
+++ b/app/src/main/java/com/demo/smartchatbotapp/di/UseCaseModule.kt
@@ -1,0 +1,30 @@
+package com.demo.smartchatbotapp.di
+
+import com.demo.smartchatbotapp.domain.usecase.GetChatHistoryUseCase
+import com.demo.smartchatbotapp.domain.usecase.SendMessageUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UseCaseModule {
+
+    @Provides
+    @Singleton
+    fun provideGetChatHistoryUseCase(
+        repository: com.demo.smartchatbotapp.domain.repository.ChatRepository
+    ): GetChatHistoryUseCase {
+        return GetChatHistoryUseCase(repository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSendMessageUseCase(
+        repository: com.demo.smartchatbotapp.domain.repository.ChatRepository
+    ): SendMessageUseCase {
+        return SendMessageUseCase(repository)
+    }
+} 

--- a/app/src/main/java/com/demo/smartchatbotapp/di/ViewModelModule.kt
+++ b/app/src/main/java/com/demo/smartchatbotapp/di/ViewModelModule.kt
@@ -1,0 +1,27 @@
+package com.demo.smartchatbotapp.di
+
+import com.demo.smartchatbotapp.ui.viewmodel.ChatViewModel
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+import com.demo.smartchatbotapp.domain.usecase.GetChatHistoryUseCase
+import com.demo.smartchatbotapp.domain.usecase.SendMessageUseCase
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object ViewModelModule {
+
+    @Provides
+    @ViewModelScoped
+    fun provideChatViewModel(
+        getChatHistoryUseCase: GetChatHistoryUseCase,
+        sendMessageUseCase: SendMessageUseCase
+    ): ChatViewModel {
+        return ChatViewModel(
+            getChatHistoryUseCase = getChatHistoryUseCase,
+            sendMessageUseCase = sendMessageUseCase
+        )
+    }
+} 

--- a/app/src/main/java/com/demo/smartchatbotapp/domain/repository/ChatRepository.kt
+++ b/app/src/main/java/com/demo/smartchatbotapp/domain/repository/ChatRepository.kt
@@ -1,9 +1,10 @@
 package com.demo.smartchatbotapp.domain.repository
 
 import com.demo.smartchatbotapp.domain.model.ChatMessage
+import kotlinx.coroutines.flow.Flow
 
 interface ChatRepository {
-    suspend fun getChatHistory(): List<ChatMessage>
-    suspend fun sendMessage(message: String): Result<ChatMessage>
-    suspend fun clearChatHistory() // Add this line
+    fun getChatHistory(): Flow<List<ChatMessage>>
+    suspend fun sendMessage(content: String): Result<ChatMessage>
+    suspend fun clearChatHistory()
 } 

--- a/app/src/main/java/com/demo/smartchatbotapp/domain/usecase/GetChatHistoryUseCase.kt
+++ b/app/src/main/java/com/demo/smartchatbotapp/domain/usecase/GetChatHistoryUseCase.kt
@@ -1,0 +1,14 @@
+package com.demo.smartchatbotapp.domain.usecase
+
+import com.demo.smartchatbotapp.domain.model.ChatMessage
+import com.demo.smartchatbotapp.domain.repository.ChatRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetChatHistoryUseCase @Inject constructor(
+    private val repository: ChatRepository
+) {
+    operator fun invoke(): Flow<List<ChatMessage>> {
+        return repository.getChatHistory()
+    }
+} 

--- a/app/src/main/java/com/demo/smartchatbotapp/ui/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/demo/smartchatbotapp/ui/viewmodel/ChatViewModel.kt
@@ -8,7 +8,9 @@ import com.demo.smartchatbotapp.domain.usecase.SendMessageUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -19,38 +21,33 @@ class ChatViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _chatState = MutableStateFlow<ChatState>(ChatState.Loading)
-    val chatState: StateFlow<ChatState> = _chatState.asStateFlow()
+    val chatState: StateFlow<ChatState> = _chatState
 
     init {
         loadChatHistory()
     }
 
     private fun loadChatHistory() {
-        viewModelScope.launch {
-            try {
-                val messages = getChatHistoryUseCase()
+        getChatHistoryUseCase()
+            .onEach { messages ->
                 _chatState.value = ChatState.Success(messages)
-            } catch (e: Exception) {
-                _chatState.value = ChatState.Error(e.message ?: "Failed to load chat history")
             }
-        }
+            .catch { error ->
+                _chatState.value = ChatState.Error(error.message ?: "Unknown error occurred")
+            }
+            .launchIn(viewModelScope)
     }
 
-    fun sendMessage(message: String) {
+    fun sendMessage(content: String) {
         viewModelScope.launch {
-            try {
-                sendMessageUseCase(message).fold(
-                    onSuccess = { newMessage ->
-                        val currentMessages = (_chatState.value as? ChatState.Success)?.messages ?: emptyList()
-                        _chatState.value = ChatState.Success(currentMessages + newMessage)
-                    },
-                    onFailure = { error ->
-                        _chatState.value = ChatState.Error(error.message ?: "Failed to send message")
-                    }
-                )
-            } catch (e: Exception) {
-                _chatState.value = ChatState.Error(e.message ?: "Failed to send message")
-            }
+            _chatState.value = ChatState.Loading
+            sendMessageUseCase(content)
+                .onSuccess { message ->
+                    // The chat history will be updated automatically through Flow
+                }
+                .onFailure { error ->
+                    _chatState.value = ChatState.Error(error.message ?: "Failed to send message")
+                }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,8 @@ coroutines = "1.7.3"
 hiltNavigation = "1.1.0"
 navigation = "2.7.7"
 compose-compiler = "1.5.8"
+okhttp = "4.12.0"
+javax-annotation = "1.3.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -47,6 +49,10 @@ room-compiler = { group = "androidx.room", name = "room-compiler", version.ref =
 retrofit-core = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-moshi = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }
 
+# OkHttp
+okhttp-core = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+
 # Moshi
 moshi-core = { group = "com.squareup.moshi", name = "moshi", version.ref = "moshi" }
 moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
@@ -58,6 +64,9 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 
 # Navigation
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
+
+# Annotations
+javax-annotation = { group = "javax.annotation", name = "javax.annotation-api", version.ref = "javax-annotation" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- Added Retrofit service definition in ChatApiService for the DeepSeek /v1/chat/completions endpoint.
- Implemented Moshi-compatible data classes (DeepSeekRequest, DeepSeekResponse, and nested models) for API communication.
- Refactored ChatRepositoryImpl#sendMessage to:
  - Construct requests for the DeepSeek API.
  - Call the API to fetch bot responses.
  - Parse responses and save both user and bot messages to Room.